### PR TITLE
Fixes access to scope variables when not using "ratio" attribute.

### DIFF
--- a/scripts/directives/cropme.coffee
+++ b/scripts/directives/cropme.coffee
@@ -101,7 +101,7 @@ angular.module("cropme").directive "cropme", ($swipe, $window, $timeout, $rootSc
 				if scope.ratio
 					throw "You can't specify both destinationHeight and ratio, destinationHeight = destinationWidth * ratio"
 				else
-					scope.ratio = destinationHeight / destinationWidth
+					scope.ratio = scope.destinationHeight / scope.destinationWidth
 			else if scope.ratio
 				scope.destinationHeight = scope.destinationWidth * scope.ratio
 			if scope.ratio and scope.height and scope.destinationHeight > scope.height


### PR DESCRIPTION
This fix access to undefined vars when using "destination-height" + "destination-width" attributes instead of "ratio" + "destination-width" attributes.
