### PR TITLE
subtract window.scrollY from e.pageY to fix cropme in a modal frame

### DIFF
--- a/scripts/directives/cropme.coffee
+++ b/scripts/directives/cropme.coffee
@@ -253,7 +253,7 @@ angular.module("cropme").directive "cropme", ($swipe, $window, $timeout, $rootSc
 			deferred.promise
 
 		scope.mousemove = (e) ->
-			scope.colResizePointer = switch isNearBorders({x: e.pageX, y:e.pageY})
+			scope.colResizePointer = switch isNearBorders({x: e.pageX, y:(e.pageY - window.scrollY)})
 				when 'top' then 'ne-resize'
 				when 'right', 'bottom' then 'se-resize'
 				when 'left' then 'sw-resize'


### PR DESCRIPTION
when you put the cropme directive in a modal (bootstrap like) and the page is scrolled when this modal opens, the colResizePointer breaks. so to fixe it, i`ve subtract window.scrollY from e.pageY. 